### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ mkl-fft==1.3.0
 mkl-random
 mkl-service==2.3.0
 numpy==1.20.3
-Pillow==8.2.0
+Pillow>=8.3.2
 six
 torch==1.9.0
 torchvision==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2021.5.30
-faiss==1.7.1
+faiss>=1.5.3
 h5py==3.2.1
 matplotlib
 mkl-fft==1.3.0


### PR DESCRIPTION
Increased the Pillow version because <8.3.2 contained security issues. Also changed the faiss version to the most recent on pypi; the one specified can no longer be found.

Successfully ran `pip install -e .`